### PR TITLE
Resolved handleEntityCacheClear not clearing EntityStorage data

### DIFF
--- a/src/main/java/com/bgsoftware/wildstacker/listeners/EntitiesListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/EntitiesListener.java
@@ -918,6 +918,7 @@ public final class EntitiesListener implements Listener {
     private void handleEntityCacheClear(LivingEntity livingEntity) {
         // Removing the entity from cache.
         plugin.getDataHandler().CACHED_ENTITIES.remove(livingEntity.getUniqueId());
+        EntityStorage.clearMetadata(livingEntity);
     }
 
     private void handleEntityShear(Cancellable cancellable, Entity entity) {


### PR DESCRIPTION
Hey, there is an issue that I noticed on Spigot 1.8.8, not sure about recent versions.

Basically, I have a plugin that cancels SpawnerSpawnEvent on NORMAL priority (and it gets drops from WildStackerAPI), but it seems as if there are hundreds of spawners, `EntityStorage` has a **memory leak** and fills server memory gradually.

I didn't have the time to debug which exact part causes this, so currently I implemented this solution.

Let me know if you need more info or you are having issues recreating the issue. **I can create an dedicated issue for this, but I think this will be fine as well**.