### PR TITLE
Added another LootTable API method (without the use of an LivingEntity)

### DIFF
--- a/API/src/main/java/com/bgsoftware/wildstacker/api/WildStackerAPI.java
+++ b/API/src/main/java/com/bgsoftware/wildstacker/api/WildStackerAPI.java
@@ -115,12 +115,22 @@ public final class WildStackerAPI {
     }
 
     /**
-     * Returns the loot loot of an entity.
+     * Returns the loot of an entity.
      *
      * @param livingEntity An entity to check
      */
     public static LootTable getLootTable(LivingEntity livingEntity) {
         return instance.getSystemManager().getLootTable(livingEntity);
+    }
+
+    /**
+     * Returns the loot from an entity type name.
+     *
+     * @param entityTypeName An entity type name to use
+     * @param isBaby Should baby table be used
+     */
+    public static LootTable getLootTable(String entityTypeName, boolean isBaby) {
+        return instance.getSystemManager().getLootTable(entityTypeName, isBaby);
     }
 
     /**

--- a/API/src/main/java/com/bgsoftware/wildstacker/api/handlers/SystemManager.java
+++ b/API/src/main/java/com/bgsoftware/wildstacker/api/handlers/SystemManager.java
@@ -300,6 +300,15 @@ public interface SystemManager {
     LootTable getLootTable(LivingEntity livingEntity);
 
     /**
+     * Get a loot-table from an entity type name.
+     *
+     * @param entityTypeName the entity type name
+     * @param isBaby should baby table be used
+     * @return loot-table
+     */
+    LootTable getLootTable(String entityTypeName, boolean isBaby);
+
+    /**
      * Get a stacked snapshot of a chunk.
      *
      * @param chunk    The chunk

--- a/API/src/main/java/com/bgsoftware/wildstacker/api/loot/LootTable.java
+++ b/API/src/main/java/com/bgsoftware/wildstacker/api/loot/LootTable.java
@@ -18,6 +18,15 @@ public interface LootTable {
     List<ItemStack> getDrops(StackedEntity stackedEntity, int lootBonusLevel, int stackAmount);
 
     /**
+     * Get the drops of a loot table using a fortune level and a stack size.
+     *
+     * @param lootBonusLevel the fortune level
+     * @param stackAmount    the stack size
+     * @return The drops of the loot table
+     */
+    List<ItemStack> getDrops(int lootBonusLevel, int stackAmount);
+
+    /**
      * Get the vanilla exp of the entity using a stack size.
      * In 1.19 or later, this method must be called synchronized if there's no custom exp set
      * in the entity's loot table. Therefore, in case of async call, -1 will be returned.

--- a/src/main/java/com/bgsoftware/wildstacker/handlers/LootHandler.java
+++ b/src/main/java/com/bgsoftware/wildstacker/handlers/LootHandler.java
@@ -256,4 +256,11 @@ public final class LootHandler {
         return lootTables.getOrDefault(entityTypeName, lootTables.get("EMPTY"));
     }
 
+    public LootTable getLootTable(String entityTypeName, boolean isBaby) {
+        if (isBaby)
+            entityTypeName += "_BABY";
+
+        return lootTables.getOrDefault(entityTypeName, lootTables.get("EMPTY"));
+    }
+
 }

--- a/src/main/java/com/bgsoftware/wildstacker/handlers/SystemHandler.java
+++ b/src/main/java/com/bgsoftware/wildstacker/handlers/SystemHandler.java
@@ -612,6 +612,11 @@ public final class SystemHandler implements SystemManager {
     }
 
     @Override
+    public LootTable getLootTable(String entityTypeName, boolean isBaby) {
+        return plugin.getLootHandler().getLootTable(entityTypeName, isBaby);
+    }
+
+    @Override
     public StackedSnapshot getStackedSnapshot(Chunk chunk, boolean loadData) {
         return getStackedSnapshot(chunk);
     }

--- a/src/main/java/com/bgsoftware/wildstacker/loot/LootItem.java
+++ b/src/main/java/com/bgsoftware/wildstacker/loot/LootItem.java
@@ -204,6 +204,25 @@ public class LootItem {
         return itemStack;
     }
 
+    public ItemStack getItemStack(int amountOfItems, int lootBonusLevel) {
+        ItemStack itemStack = this.itemStack.clone();
+
+        int lootingBonus = 0;
+
+        if (looting && lootBonusLevel > 0) {
+            lootingBonus = Random.nextInt(lootBonusLevel + 1);
+        }
+
+        int itemAmount = Random.nextInt(min + lootingBonus, max + lootingBonus, amountOfItems);
+
+        if (itemAmount <= 0)
+            return null;
+
+        itemStack.setAmount(itemAmount);
+
+        return itemStack;
+    }
+
     @Override
     public String toString() {
         return "LootItem{item=" + itemStack + ",burnable=" + burnableItem + "}";

--- a/src/main/java/com/bgsoftware/wildstacker/loot/LootPair.java
+++ b/src/main/java/com/bgsoftware/wildstacker/loot/LootPair.java
@@ -136,6 +136,25 @@ public class LootPair {
         return items;
     }
 
+    public List<ItemStack> getItems(int amountOfPairs, int lootBonusLevel) {
+        List<ItemStack> items = new ArrayList<>();
+
+        for (LootItem lootItem : lootItems) {
+            int amountOfItems = (int) (lootItem.getChance(lootBonusLevel, lootingChance) * amountOfPairs / 100);
+
+            if (amountOfItems == 0) {
+                amountOfItems = Random.nextChance(lootItem.getChance(lootBonusLevel, lootingChance), amountOfPairs);
+            }
+
+            ItemStack itemStack = lootItem.getItemStack(amountOfItems, lootBonusLevel);
+
+            if (itemStack != null)
+                items.add(itemStack);
+        }
+
+        return items;
+    }
+
     public void executeCommands(Player player, int amountOfPairs, int lootBonusLevel) {
         List<String> commands = new ArrayList<>();
 

--- a/src/main/java/com/bgsoftware/wildstacker/loot/LootTable.java
+++ b/src/main/java/com/bgsoftware/wildstacker/loot/LootTable.java
@@ -115,6 +115,26 @@ public class LootTable implements com.bgsoftware.wildstacker.api.loot.LootTable 
     }
 
     @Override
+    public List<ItemStack> getDrops(int lootBonusLevel, int stackAmount) {
+        List<ItemStack> drops = new ArrayList<>();
+
+        int amountOfDifferentPairs = max == -1 || min == -1 ? stackAmount : max == min ? max * stackAmount :
+                Random.nextInt(min, max, stackAmount);
+
+        for (LootPair lootPair : lootPairs) {
+            int amountOfPairs = (int) (lootPair.getChance() * amountOfDifferentPairs / 100);
+
+            if (amountOfPairs == 0) {
+                amountOfPairs = Random.nextChance(lootPair.getChance(), amountOfDifferentPairs);
+            }
+
+            drops.addAll(lootPair.getItems(amountOfPairs, lootBonusLevel));
+        }
+
+        return drops;
+    }
+
+    @Override
     public int getExp(StackedEntity stackedEntity, int stackAmount) {
         int exp = 0;
 


### PR DESCRIPTION
Some spigot forks have a "PreSpawnerSpawnEvent" and similar events that do not use LivingEntity (instead, events have EntityType). It would be useful to have another API method to get a LootTable.

I know this isn't perfect as the EntityTypeName would need to be correct for the method to work, but EntityTypes conversion can be accessed and some of logic there can be recreated outside WildStacker, if needed.

**NOTE:** This could be clearner if EntityTypes would be exposed to API directly...