### PR TITLE
Fixed and improved "multiply-..." options

### DIFF
--- a/src/main/java/com/bgsoftware/wildstacker/handlers/SettingsHandler.java
+++ b/src/main/java/com/bgsoftware/wildstacker/handlers/SettingsHandler.java
@@ -98,8 +98,9 @@ public final class SettingsHandler {
     public final boolean entitiesStackingEnabled, entitiesParticlesEnabled, linkedEntitiesEnabled, nerfedEntitiesTeleport,
             stackDownEnabled, keepFireEnabled, mythicMobsCustomNameEnabled, stackAfterBreed, smartBreedingEnabled,
             smartBreedingConsumeEntireInventory, entitiesHideNames, entitiesNamesToggleEnabled, entitiesFastKill,
-            eggLayMultiply, scuteMultiply, entitiesClearEquipment, spawnCorpses, entitiesOneShotEnabled, storeEntities,
-            superiorSkyblockHook, multiplyDrops, multiplySnifferSeeds, multiplyExp, spreadDamage, entitiesFillVehicles;
+            entitiesClearEquipment, spawnCorpses, entitiesOneShotEnabled, storeEntities, superiorSkyblockHook,
+            multiplyDrops, multiplyExp, multiplyArmadilloScutes, multiplyChickenEggs, multiplySnifferSeeds,
+            multiplyTurtleScutes, spreadDamage, entitiesFillVehicles;
     public final long entitiesStackInterval;
     public final String entitiesCustomName, entitiesNamesToggleCommand;
     public final NameBuilder<StackedEntity> entitiesNameBuilder;
@@ -304,8 +305,6 @@ public final class SettingsHandler {
             entitiesExpPickupSound = null;
         }
         this.entitiesExpPickupSound = entitiesExpPickupSound;
-        eggLayMultiply = cfg.getBoolean("entities.egg-lay-multiply", true);
-        scuteMultiply = cfg.getBoolean("entities.scute-multiply", true);
         entitiesClearEquipment = cfg.getBoolean("entities.clear-equipment", false);
         spawnCorpses = cfg.getBoolean("entities.spawn-corpses", true);
         entitiesOneShotEnabled = cfg.getBoolean("entities.one-shot.enabled", false);
@@ -315,8 +314,11 @@ public final class SettingsHandler {
         storeEntities = cfg.getBoolean("entities.store-entities", true);
         superiorSkyblockHook = cfg.getBoolean("entities.superiorskyblock-hook", false);
         multiplyDrops = cfg.getBoolean("entities.multiply-drops", true);
-        multiplySnifferSeeds = cfg.getBoolean("entities.multiply-sniffer-seeds", true);
         multiplyExp = cfg.getBoolean("entities.multiply-exp", true);
+        multiplyArmadilloScutes = cfg.getBoolean("entities.multiply-armadillo-scutes", true);
+        multiplyChickenEggs = cfg.getBoolean("entities.multiply-chicken-eggs", true);
+        multiplySnifferSeeds = cfg.getBoolean("entities.multiply-sniffer-seeds", true);
+        multiplyTurtleScutes = cfg.getBoolean("entities.multiply-turtle-eggs", true);
         spreadDamage = cfg.getBoolean("entities.spread-damage", false);
         entitiesFilteredTransforms = cfg.getStringList("entities.filtered-transforms");
         entitiesFillVehicles = cfg.getBoolean("entities.entities-fill-vehicles");
@@ -764,6 +766,12 @@ public final class SettingsHandler {
         }
         if (cfg.isBoolean("entities.smart-breeding")) {
             cfg.set("entities.smart-breeding.enabled", cfg.getBoolean("entities.smart-breeding"));
+        }
+        if (cfg.contains("entities.egg-lay-multiply")) {
+            cfg.set("entities.multiply-chicken-eggs", cfg.getBoolean("entities.egg-lay-multiply"));
+        }
+        if (cfg.contains("entities.scute-multiply")) {
+            cfg.set("entities.multiply-turtle-scutes", cfg.getBoolean("entities.scute-multiply"));
         }
     }
 

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/ItemsListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/ItemsListener.java
@@ -3,7 +3,6 @@ package com.bgsoftware.wildstacker.listeners;
 import com.bgsoftware.common.reflection.ReflectMethod;
 import com.bgsoftware.wildstacker.WildStackerPlugin;
 import com.bgsoftware.wildstacker.api.enums.EntityFlag;
-import com.bgsoftware.wildstacker.api.objects.StackedEntity;
 import com.bgsoftware.wildstacker.api.objects.StackedItem;
 import com.bgsoftware.wildstacker.listeners.events.EventsListener;
 import com.bgsoftware.wildstacker.objects.WStackedEntity;
@@ -59,8 +58,9 @@ public final class ItemsListener implements Listener {
         } catch (Exception ignored) {
         }
 
-        EventsListener.registerEggLayListener(this::onEggLay);
-        EventsListener.registerScuteDropListener(this::onScuteDrop);
+        EventsListener.registerArmadilloScuteDropListener(this::onArmadilloScuteDrop);
+        EventsListener.registerChickenEggLayListener(this::onChickenEggLay);
+        EventsListener.registerTurtleScuteDropListener(this::onTurtleScuteDrop);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -103,18 +103,6 @@ public final class ItemsListener implements Listener {
         EntityStorage.setMetadata(e.getItemDrop(), EntityFlag.DROPPED_BY_PLAYER, true);
     }
 
-    private void onEggLay(Chicken chicken, Item egg) {
-        if (!plugin.getSettings().eggLayMultiply || !EntityUtils.isStackable(chicken))
-            return;
-
-        StackedEntity stackedEntity = WStackedEntity.of(chicken);
-        if (stackedEntity.getStackAmount() > 1) {
-            ItemStack eggItem = egg.getItemStack();
-            eggItem.setAmount(stackedEntity.getStackAmount());
-            egg.setItemStack(eggItem);
-        }
-    }
-
     //This method will be fired even if stacking-drops is disabled.
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemDespawn(ItemDespawnEvent e) {
@@ -146,14 +134,46 @@ public final class ItemsListener implements Listener {
         }
     }
 
-    private void onScuteDrop(Entity turtle, Item scute) {
-        if (!plugin.getSettings().scuteMultiply || !EntityUtils.isStackable(turtle))
+    private void onArmadilloScuteDrop(Entity armadillo, Item armadilloScute) {
+        if (!plugin.getSettings().multiplyArmadilloScutes || !EntityUtils.isStackable(armadillo)) {
             return;
+        }
 
-        StackedEntity stackedEntity = WStackedEntity.of(turtle);
-        ItemStack scuteItem = scute.getItemStack();
-        scuteItem.setAmount(scuteItem.getAmount() * stackedEntity.getStackAmount());
-        scute.setItemStack(scuteItem);
+        int stackAmount = WStackedEntity.of(armadillo).getStackAmount();
+
+        if (stackAmount > 1) {
+            ItemStack armadilloScuteItem = armadilloScute.getItemStack();
+            armadilloScuteItem.setAmount(armadilloScuteItem.getAmount() * stackAmount);
+            armadilloScute.setItemStack(armadilloScuteItem);
+        }
+    }
+
+    private void onChickenEggLay(Chicken chicken, Item egg) {
+        if (!plugin.getSettings().multiplyChickenEggs || !EntityUtils.isStackable(chicken)) {
+            return;
+        }
+
+        int stackAmount = WStackedEntity.of(chicken).getStackAmount();
+
+        if (stackAmount > 1) {
+            ItemStack eggItem = egg.getItemStack();
+            eggItem.setAmount(eggItem.getAmount() * stackAmount);
+            egg.setItemStack(eggItem);
+        }
+    }
+
+    private void onTurtleScuteDrop(Entity turtle, Item turtleScute) {
+        if (!plugin.getSettings().multiplyTurtleScutes || !EntityUtils.isStackable(turtle)) {
+            return;
+        }
+
+        int stackAmount = WStackedEntity.of(turtle).getStackAmount();
+
+        if (stackAmount > 1) {
+            ItemStack turtleScuteItem = turtleScute.getItemStack();
+            turtleScuteItem.setAmount(turtleScuteItem.getAmount() * stackAmount);
+            turtleScute.setItemStack(turtleScuteItem);
+        }
     }
 
     private boolean isChunkLimit(Chunk chunk) {

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/events/EventsListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/events/EventsListener.java
@@ -3,9 +3,11 @@ package com.bgsoftware.wildstacker.listeners.events;
 import com.bgsoftware.wildstacker.WildStackerPlugin;
 import com.bgsoftware.wildstacker.utils.ServerVersion;
 import com.bgsoftware.wildstacker.utils.entity.EntitiesGetter;
+import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.legacy.Materials;
 import org.bukkit.Material;
 import org.bukkit.entity.Chicken;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -13,71 +15,99 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.ItemSpawnEvent;
 
 import javax.annotation.Nullable;
-import java.util.function.Supplier;
 
 public final class EventsListener {
 
     private static WildStackerPlugin plugin;
 
     @Nullable
-    private static IEggLayListener eggLayListener;
+    private static IArmadilloScuteDropListener armadilloScuteDropListener;
     @Nullable
-    private static IScuteDropListener scuteDropListener;
+    private static IChickenEggLayListener chickenEggLayListener;
+    @Nullable
+    private static ITurtleScuteDropListener turtleScuteDropListener;
 
     public static void register(WildStackerPlugin plugin) {
         EventsListener.plugin = plugin;
 
-        plugin.getServer().getPluginManager().registerEvents(new EggLay(), plugin);
+        if (ServerVersion.isAtLeast(ServerVersion.v1_20)) {
+            plugin.getServer().getPluginManager().registerEvents(new ArmadilloScuteDrop(), plugin);
+        }
 
-        if (ServerVersion.isAtLeast(ServerVersion.v1_13))
-            plugin.getServer().getPluginManager().registerEvents(new ScuteDrop(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new ChickenEggLay(), plugin);
+
+        if (ServerVersion.isAtLeast(ServerVersion.v1_13)) {
+            plugin.getServer().getPluginManager().registerEvents(new TurtleScuteDrop(), plugin);
+        }
     }
 
-    public static void registerEggLayListener(IEggLayListener eggLayListener) {
-        EventsListener.eggLayListener = eggLayListener;
+    public static void registerArmadilloScuteDropListener(IArmadilloScuteDropListener armadilloScuteDropListener) {
+        EventsListener.armadilloScuteDropListener = armadilloScuteDropListener;
     }
 
-    public static void registerScuteDropListener(IScuteDropListener scuteDropListener) {
-        EventsListener.scuteDropListener = scuteDropListener;
+    public static void registerChickenEggLayListener(IChickenEggLayListener eggLayListener) {
+        EventsListener.chickenEggLayListener = eggLayListener;
     }
 
-    private static class EggLay implements Listener {
+    public static void registerTurtleScuteDropListener(ITurtleScuteDropListener turtleScuteDropListener) {
+        EventsListener.turtleScuteDropListener = turtleScuteDropListener;
+    }
+
+    private static class ArmadilloScuteDrop implements Listener {
+
+        @Nullable
+        private static final EntityType ARMADILLO = EntityUtils.getEntityTypeSafe("ARMADILLO");
+        @Nullable
+        private static final Material ARMADILLO_SCUTE = Materials.getMaterialOrNull("ARMADILLO_SCUTE");
 
         @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-        public void onEggLay(ItemSpawnEvent e) {
-            if (eggLayListener == null || !Materials.isChickenEgg(e.getEntity().getItemStack()))
+        public void onArmadilloScuteDrop(ItemSpawnEvent e) {
+            if (armadilloScuteDropListener == null || e.getEntity().getItemStack().getType() != ARMADILLO_SCUTE) {
                 return;
+            }
 
-            Item egg = e.getEntity();
+            Item armadilloScute = e.getEntity();
 
-            EntitiesGetter.getNearbyEntities(e.getEntity().getLocation(), 2, entity ->
-                    entity instanceof Chicken && plugin.getNMSEntities().getEggLayTime((Chicken) entity) <= 0
-            ).findFirst().ifPresent(chicken -> eggLayListener.apply((Chicken) chicken, egg));
+            EntitiesGetter.getNearbyEntities(e.getEntity().getLocation(), 2,
+                            entity -> entity.getType() == ARMADILLO)
+                    .findFirst().ifPresent(armadillo -> armadilloScuteDropListener.apply(armadillo, armadilloScute));
         }
 
     }
 
-    private static class ScuteDrop implements Listener {
-
-        @Nullable
-        private static final Material SCUTE = ((Supplier<Material>) () -> {
-            try {
-                return Material.valueOf("SCUTE");
-            } catch (IllegalArgumentException error) {
-                return null;
-            }
-        }).get();
+    private static class ChickenEggLay implements Listener {
 
         @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-        public void onScuteDrop(ItemSpawnEvent e) {
-            if (scuteDropListener == null || e.getEntity().getItemStack().getType() != SCUTE)
+        public void onChickenEggLay(ItemSpawnEvent e) {
+            if (chickenEggLayListener == null || !Materials.isChickenEgg(e.getEntity().getItemStack())) {
                 return;
+            }
 
-            Item scute = e.getEntity();
+            Item egg = e.getEntity();
+
+            EntitiesGetter.getNearbyEntities(e.getEntity().getLocation(), 2, entity ->
+                            entity instanceof Chicken && plugin.getNMSEntities().getEggLayTime((Chicken) entity) <= 0)
+                    .findFirst().ifPresent(chicken -> chickenEggLayListener.apply((Chicken) chicken, egg));
+        }
+
+    }
+
+    private static class TurtleScuteDrop implements Listener {
+
+        @Nullable
+        private static final Material TURTLE_SCUTE = Materials.getMaterialOrNull("TURTLE_SCUTE", "SCUTE");
+
+        @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+        public void onTurtleScuteDrop(ItemSpawnEvent e) {
+            if (turtleScuteDropListener == null || e.getEntity().getItemStack().getType() != TURTLE_SCUTE) {
+                return;
+            }
+
+            Item turtleScute = e.getEntity();
 
             EntitiesGetter.getNearbyEntities(e.getEntity().getLocation(), 2,
                             entity -> entity instanceof org.bukkit.entity.Turtle)
-                    .findFirst().ifPresent(turtle -> scuteDropListener.apply(turtle, scute));
+                    .findFirst().ifPresent(turtle -> turtleScuteDropListener.apply(turtle, turtleScute));
         }
 
     }

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/events/IArmadilloScuteDropListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/events/IArmadilloScuteDropListener.java
@@ -3,8 +3,8 @@ package com.bgsoftware.wildstacker.listeners.events;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 
-public interface IScuteDropListener {
+public interface IArmadilloScuteDropListener {
 
-    void apply(Entity turtle, Item scute);
+    void apply(Entity armadillo, Item armadilloScute);
 
 }

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/events/IChickenEggLayListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/events/IChickenEggLayListener.java
@@ -3,7 +3,7 @@ package com.bgsoftware.wildstacker.listeners.events;
 import org.bukkit.entity.Chicken;
 import org.bukkit.entity.Item;
 
-public interface IEggLayListener {
+public interface IChickenEggLayListener {
 
     void apply(Chicken chicken, Item egg);
 

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/events/ITurtleScuteDropListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/events/ITurtleScuteDropListener.java
@@ -1,0 +1,10 @@
+package com.bgsoftware.wildstacker.listeners.events;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+
+public interface ITurtleScuteDropListener {
+
+    void apply(Entity turtle, Item turtleScute);
+
+}

--- a/src/main/java/com/bgsoftware/wildstacker/utils/legacy/Materials.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/legacy/Materials.java
@@ -153,6 +153,18 @@ public enum Materials {
         }
     }
 
+    @Nullable
+    public static Material getMaterialOrNull(String... names) {
+        for (String name : names) {
+            try {
+                return Material.valueOf(name);
+            } catch (Exception ignored) {
+            }
+        }
+
+        return null;
+    }
+
     private static EnumMap<Material, EnumSet<Tag>> setupMaterialTags() {
         EnumMap<Material, EnumSet<Tag>> enumMap = new EnumMap<>(Material.class);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -434,12 +434,6 @@ entities:
   # You can set this to '' if you want to disable it.
   exp-pickup-sound: ENTITY_EXPERIENCE_ORB_PICKUP
 
-  # Should eggs that are laid by stacked chickens be multiplied by it's stack size?
-  egg-lay-multiply: true
-
-  # Should scout that are dropped by grown turtles by multiplied by it's stack size?
-  scute-multiply: true
-
   # Should vanilla equipment of entities get cleared after they unstack?
   clear-equipment: false
 
@@ -471,11 +465,24 @@ entities:
   # Should drops get calculated in relation to the amount of mobs that died?
   multiply-drops: true
 
-  # Should sniffer seeds get calculated in relation to the amount of mobs in the stack?
-  multiply-sniffer-seeds: true
-
   # Should exp get calculated in relation to the amount of mobs that died?
   multiply-exp: true
+
+  # Should armadillo scutes that are dropped by stacked armadillos
+  # get calculated in relation to the amount of mobs in the stack?
+  multiply-armadillo-scutes: true
+
+  # Should chicken eggs that are laid by stacked chickens
+  # get calculated in relation to the amount of mobs in the stack?
+  multiply-chicken-eggs: true
+
+  # Should sniffer seeds that are dropped by stacked sniffers
+  # get calculated in relation to the amount of mobs in the stack?
+  multiply-sniffer-seeds: true
+
+  # Should turtle scutes that are dropped by stacked turtles
+  # get calculated in relation to the amount of mobs in the stack?
+  multiply-turtle-scutes: true
 
   # Should damage be spread to the next stack?
   # If you deal more damage than the health of the entity, the rest of the damage will be dealt to the next stack.


### PR DESCRIPTION
Fixes #1144

# Changelog #
- Added a feature to multiply Armadillo Scutes based on the mob's stack size, with a toggle option in the config.
- Fixed the Turtle Scutes multiplication feature, in version 1.20.5, the item name changed from "SCUTE" to "TURTLE_SCUTE", causing the feature to fail on newer versions.
- Standardized the "multiply-..." config option names and comments, including a corresponding conversion.
- Cleaned up the code responsible for multiplying Armadillo Scutes, Chicken Eggs, and Turtle Scutes.