### PR TITLE
Fixed renaming stacked entities using name tags

### DIFF
--- a/src/main/java/com/bgsoftware/wildstacker/listeners/EntitiesListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/EntitiesListener.java
@@ -439,6 +439,7 @@ public final class EntitiesListener implements Listener {
                 || e.getRightClicked() instanceof EnderDragon || !EntityUtils.isStackable(e.getRightClicked()))
             return;
 
+        String displayName = inHand.getItemMeta().getDisplayName();
         StackedEntity stackedEntity = WStackedEntity.of(e.getRightClicked());
 
         if (plugin.getSettings().entitiesStackingEnabled && StackSplit.NAME_TAG.isEnabled()) {
@@ -447,7 +448,7 @@ public final class EntitiesListener implements Listener {
                     stackedEntity.setCustomName("");
                     stackedEntity.decreaseStackAmount(1, true);
                     StackedEntity duplicated = stackedEntity.spawnDuplicate(1);
-                    duplicated.setCustomName(inHand.getItemMeta().getDisplayName());
+                    duplicated.setCustomName(displayName);
                     ((WStackedEntity) duplicated).setNameTag();
                 } else {
                     ((WStackedEntity) stackedEntity).setNameTag();


### PR DESCRIPTION
Fixes #1032 

Since we are changing the stacked entity's name two seconds later, we cannot wait until then to retrieve the name tag's display name, because if we had only one name tag, it is no longer in the inventory because we have already used it.