### PR TITLE
Use chunk index for barrel and spawner radius searches

### DIFF
--- a/src/main/java/com/bgsoftware/wildstacker/data/AbstractBlockDataStore.java
+++ b/src/main/java/com/bgsoftware/wildstacker/data/AbstractBlockDataStore.java
@@ -7,6 +7,7 @@ import com.bgsoftware.wildstacker.utils.data.structures.Location2ObjectMap;
 import org.bukkit.Location;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -175,6 +176,44 @@ public abstract class AbstractBlockDataStore<T extends StackedObject<?>, U exten
         List<T> all = new LinkedList<>();
         collectFromChunk(worldName, x, z, all);
         return all;
+    }
+
+    /**
+     * Returns cached objects in the same world within the inclusive XYZ block bounds.
+     */
+    public List<T> collectInRange(Location location, int range) {
+        if (this.store.isEmpty() || range < 0)
+            return Collections.emptyList();
+
+        String worldName = location.getWorld().getName();
+        long minX = (long) location.getBlockX() - range, minY = (long) location.getBlockY() - range, minZ = (long) location.getBlockZ() - range;
+        long maxX = (long) location.getBlockX() + range, maxY = (long) location.getBlockY() + range, maxZ = (long) location.getBlockZ() + range;
+
+        int minChunkX = (int) (minX >> 4), maxChunkX = (int) (maxX >> 4);
+        int minChunkZ = (int) (minZ >> 4), maxChunkZ = (int) (maxZ >> 4);
+        long chunksInRange = ((long) maxChunkX - minChunkX + 1) * ((long) maxChunkZ - minChunkZ + 1);
+
+        List<T> nearby = new ArrayList<>();
+        // Use the chunk index while there are fewer chunk lookups (including empty chunks)
+        // than cached objects to check. This avoids excessive lookups for large radii.
+        if (chunksInRange < size()) {
+            for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+                for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ++) {
+                    collectFromChunk(worldName, chunkX, chunkZ, nearby);
+                }
+            }
+        } else {
+            collect(nearby);
+        }
+
+        nearby.removeIf(object -> {
+            Location loc = object.getLocation();
+            return !worldName.equals(loc.getWorld().getName()) ||
+                    loc.getBlockX() < minX || loc.getBlockX() > maxX ||
+                    loc.getBlockY() < minY || loc.getBlockY() > maxY ||
+                    loc.getBlockZ() < minZ || loc.getBlockZ() > maxZ;
+        });
+        return nearby;
     }
 
     public void collect(List<? super T> list) {

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedBarrel.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedBarrel.java
@@ -253,35 +253,7 @@ public final class WStackedBarrel extends WStackedHologramObject<Block> implemen
             if (range <= 0)
                 return Optional.empty();
 
-            Location location = getLocation();
-
-            long maxX = (long) location.getBlockX() + range, maxY = (long) location.getBlockY() + range, maxZ = (long) location.getBlockZ() + range;
-            long minX = (long) location.getBlockX() - range, minY = (long) location.getBlockY() - range, minZ = (long) location.getBlockZ() - range;
-
-            long chunksInRange = ((maxX >> 4) - (minX >> 4) + 1) * ((maxZ >> 4) - (minZ >> 4) + 1);
-
-            // Avoid walking a large number of empty chunks for large merge radii.
-            if (chunksInRange < plugin.getDataHandler().stackedBarrelStore.size()) {
-                List<StackedBarrel> nearbyBarrels = new ArrayList<>();
-                String worldName = location.getWorld().getName();
-                for (int chunkX = (int) (minX >> 4); chunkX <= (maxX >> 4); chunkX++) {
-                    for (int chunkZ = (int) (minZ >> 4); chunkZ <= (maxZ >> 4); chunkZ++) {
-                        plugin.getDataHandler().stackedBarrelStore.collectFromChunk(
-                                worldName, chunkX, chunkZ, nearbyBarrels);
-                    }
-                }
-                barrelStream = nearbyBarrels.stream();
-            } else {
-                barrelStream = plugin.getSystemManager().getStackedBarrels().stream();
-            }
-
-            barrelStream = barrelStream
-                    .filter(stackedBarrel -> {
-                        Location loc = stackedBarrel.getLocation();
-                        return loc.getBlockX() >= minX && loc.getBlockX() <= maxX &&
-                                loc.getBlockY() >= minY && loc.getBlockY() <= maxY &&
-                                loc.getBlockZ() >= minZ && loc.getBlockZ() <= maxZ;
-                    });
+            barrelStream = plugin.getDataHandler().stackedBarrelStore.collectInRange(blockLocation, range).stream();
         }
 
         Optional<StackedBarrel> barrelOptional = GeneralUtils.getClosest(blockLocation, barrelStream

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedBarrel.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedBarrel.java
@@ -255,10 +255,27 @@ public final class WStackedBarrel extends WStackedHologramObject<Block> implemen
 
             Location location = getLocation();
 
-            int maxX = location.getBlockX() + range, maxY = location.getBlockY() + range, maxZ = location.getBlockZ() + range;
-            int minX = location.getBlockX() - range, minY = location.getBlockY() - range, minZ = location.getBlockZ() - range;
+            long maxX = (long) location.getBlockX() + range, maxY = (long) location.getBlockY() + range, maxZ = (long) location.getBlockZ() + range;
+            long minX = (long) location.getBlockX() - range, minY = (long) location.getBlockY() - range, minZ = (long) location.getBlockZ() - range;
 
-            barrelStream = plugin.getSystemManager().getStackedBarrels().stream()
+            long chunksInRange = ((maxX >> 4) - (minX >> 4) + 1) * ((maxZ >> 4) - (minZ >> 4) + 1);
+
+            // Avoid walking a large number of empty chunks for large merge radii.
+            if (chunksInRange < plugin.getDataHandler().stackedBarrelStore.size()) {
+                List<StackedBarrel> nearbyBarrels = new ArrayList<>();
+                String worldName = location.getWorld().getName();
+                for (int chunkX = (int) (minX >> 4); chunkX <= (maxX >> 4); chunkX++) {
+                    for (int chunkZ = (int) (minZ >> 4); chunkZ <= (maxZ >> 4); chunkZ++) {
+                        plugin.getDataHandler().stackedBarrelStore.collectFromChunk(
+                                worldName, chunkX, chunkZ, nearbyBarrels);
+                    }
+                }
+                barrelStream = nearbyBarrels.stream();
+            } else {
+                barrelStream = plugin.getSystemManager().getStackedBarrels().stream();
+            }
+
+            barrelStream = barrelStream
                     .filter(stackedBarrel -> {
                         Location loc = stackedBarrel.getLocation();
                         return loc.getBlockX() >= minX && loc.getBlockX() <= maxX &&

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedSpawner.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedSpawner.java
@@ -100,18 +100,7 @@ public final class WStackedSpawner extends WStackedHologramObject<CreatureSpawne
             spawnerStream = plugin.getSystemManager().getStackedSpawners(getChunk()).stream();
         } else {
             int range = getMergeRadius();
-            Location location = getLocation();
-
-            int maxX = location.getBlockX() + range, maxY = location.getBlockY() + range, maxZ = location.getBlockZ() + range;
-            int minX = location.getBlockX() - range, minY = location.getBlockY() - range, minZ = location.getBlockZ() - range;
-
-            spawnerStream = plugin.getSystemManager().getStackedSpawners().stream()
-                    .filter(stackedSpawner -> {
-                        Location loc = stackedSpawner.getLocation();
-                        return loc.getBlockX() >= minX && loc.getBlockX() <= maxX &&
-                                loc.getBlockY() >= minY && loc.getBlockY() <= maxY &&
-                                loc.getBlockZ() >= minZ && loc.getBlockZ() <= maxZ;
-                    });
+            spawnerStream = plugin.getDataHandler().stackedSpawnerStore.collectInRange(getLocation(), range).stream();
         }
 
         return spawnerStream.filter(this::canStackIntoNoLimit).collect(Collectors.toList());
@@ -237,18 +226,7 @@ public final class WStackedSpawner extends WStackedHologramObject<CreatureSpawne
             if (range <= 0)
                 return Optional.empty();
 
-            Location location = getLocation();
-
-            int maxX = location.getBlockX() + range, maxY = location.getBlockY() + range, maxZ = location.getBlockZ() + range;
-            int minX = location.getBlockX() - range, minY = location.getBlockY() - range, minZ = location.getBlockZ() - range;
-
-            spawnerStream = plugin.getSystemManager().getStackedSpawners().stream()
-                    .filter(stackedSpawner -> {
-                        Location loc = stackedSpawner.getLocation();
-                        return loc.getBlockX() >= minX && loc.getBlockX() <= maxX &&
-                                loc.getBlockY() >= minY && loc.getBlockY() <= maxY &&
-                                loc.getBlockZ() >= minZ && loc.getBlockZ() <= maxZ;
-                    });
+            spawnerStream = plugin.getDataHandler().stackedSpawnerStore.collectInRange(blockLocation, range).stream();
         }
 
         Optional<StackedSpawner> spawnerOptional = GeneralUtils.getClosest(blockLocation, spawnerStream


### PR DESCRIPTION
Closes #1150.

With chunk merging disabled, barrel and spawner radius searches copy and filter the full loaded-object cache.

Add `AbstractBlockDataStore.collectInRange(Location, int)` and use it in `WStackedBarrel.runStack()`, `WStackedSpawner.runStack()` and `WStackedSpawner.getNearbySpawners()`. The helper queries the existing chunk index and filters by world and inclusive XYZ block bounds. The callers keep their stacking checks and closest-target selection.

For large radii, fall back to the cache when the number of chunk lookups, including empty chunks, reaches the number of cached objects. This is a rough cost estimate. Use `long` bounds to avoid overflow.
